### PR TITLE
fixed: can not input space

### DIFF
--- a/mozc-im.el
+++ b/mozc-im.el
@@ -124,6 +124,9 @@ INPUT-METHOD isn't used."
 
 (defun mozc-im-register-input-method ()
   "Register Mozc-im as a input method."
+  (setq minor-mode-map-alist
+        (cons (cons 'mozc-mode mozc-mode-map)
+              (assq-delete-all 'mozc-mode minor-mode-map-alist)))
   (register-input-method
    "japanese-mozc-im"
    "Japanese"


### PR DESCRIPTION
mozc.elの`(mozc-mode)`で行っている初期化処理を`mozc-im.el`では行っていないため,
スペースを入力すると`(mozc-disable-keymap)`でエラーになり,スペース入力が出来ませんでした.
初期化処理を`(mozc-im-register-input-method)`に挿入することで対策をとりました.
